### PR TITLE
Move from pbr to regular plain setup.py

### DIFF
--- a/dist_utils.py
+++ b/dist_utils.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
+#       Instead modify scripts/dist_utils.py and run 'make .sdist-requirements' to
+#       update dist_utils.py files for all components
+
+# Copyright 2020 The StackStorm Authors.
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import re
+import sys
+
+from distutils.version import StrictVersion
+
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+#
+# TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
+#       from pip?
+#
+# TODO: Dear future developer, if you are back here fixing a bug with how we parse
+#       requirements files, please look into using the packaging package on PyPI:
+#       https://packaging.pypa.io/en/latest/requirements/
+#       and specifying that in the `setup_requires` argument to `setuptools.setup()`
+#       for subpackages.
+#       At the very least we can vendorize some of their code instead of reimplementing
+#       each piece of their code every time our parsing breaks.
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode  # noqa  # pylint: disable=E0602
+
+GET_PIP = "curl https://bootstrap.pypa.io/get-pip.py | python"
+
+__all__ = [
+    "check_pip_is_installed",
+    "check_pip_version",
+    "fetch_requirements",
+    "apply_vagrant_workaround",
+    "get_version_string",
+    "parse_version_string",
+]
+
+
+def check_pip_is_installed():
+    """
+    Ensure that pip is installed.
+    """
+    try:
+        import pip  # NOQA
+    except ImportError as e:
+        print("Failed to import pip: %s" % (text_type(e)))
+        print("")
+        print("Download pip:\n%s" % (GET_PIP))
+        sys.exit(1)
+
+    return True
+
+
+def check_pip_version(min_version="6.0.0"):
+    """
+    Ensure that a minimum supported version of pip is installed.
+    """
+    check_pip_is_installed()
+
+    import pip
+
+    if StrictVersion(pip.__version__) < StrictVersion(min_version):
+        print(
+            "Upgrade pip, your version '{0}' "
+            "is outdated. Minimum required version is '{1}':\n{2}".format(
+                pip.__version__, min_version, GET_PIP
+            )
+        )
+        sys.exit(1)
+
+    return True
+
+
+def fetch_requirements(requirements_file_path):
+    """
+    Return a list of requirements and links by parsing the provided requirements file.
+    """
+    links = []
+    reqs = []
+
+    def _get_link(line):
+        vcs_prefixes = ["git+", "svn+", "hg+", "bzr+"]
+
+        for vcs_prefix in vcs_prefixes:
+            if line.startswith(vcs_prefix) or line.startswith("-e %s" % (vcs_prefix)):
+                req_name = re.findall(".*#egg=(.+)([&|@]).*$", line)
+
+                if not req_name:
+                    req_name = re.findall(".*#egg=(.+?)$", line)
+                else:
+                    req_name = req_name[0]
+
+                if not req_name:
+                    raise ValueError(
+                        'Line "%s" is missing "#egg=<package name>"' % (line)
+                    )
+
+                link = line.replace("-e ", "").strip()
+                return link, req_name[0]
+
+        return None, None
+
+    with open(requirements_file_path, "r") as fp:
+        for line in fp.readlines():
+            line = line.strip()
+
+            if line.startswith("#") or not line:
+                continue
+
+            link, req_name = _get_link(line=line)
+
+            if link:
+                links.append(link)
+            else:
+                req_name = line
+
+                if ";" in req_name:
+                    req_name = req_name.split(";")[0].strip()
+
+            reqs.append(req_name)
+
+    return (reqs, links)
+
+
+def apply_vagrant_workaround():
+    """
+    Function which detects if the script is being executed inside vagrant and if it is, it deletes
+    "os.link" attribute.
+    Note: Without this workaround, setup.py sdist will fail when running inside a shared directory
+    (nfs / virtualbox shared folders).
+    """
+    if os.environ.get("USER", None) == "vagrant":
+        del os.link
+
+
+def get_version_string(init_file):
+    """
+    Read __version__ string for an init file.
+    """
+
+    with open(init_file, "r") as fp:
+        content = fp.read()
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", content, re.M)
+        if version_match:
+            return version_match.group(1)
+
+        raise RuntimeError("Unable to find version string in %s." % (init_file))
+
+
+# alias for get_version_string
+parse_version_string = get_version_string

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,73 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
 
-import setuptools
+from setuptools import setup, find_packages
 
-setuptools.setup(
-    setup_requires=['pbr'],
-    pbr=True,
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+REQUIREMENTS_FILE = os.path.join(BASE_DIR, "requirements.txt")
+
+from dist_utils import fetch_requirements
+
+install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
+
+
+setup(
+    name="logshipper",
+    author="Koert van der Veer",
+    author_email="koert@ondergetekende.nl",
+    summary="Gathers, filters, mangles and redistribute log messages",
+    description_file="README.md",
+    license="Apache-2",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: System Administrators",
+        "Intended Audience :: Information Technology",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+    ],
+    install_requires=install_reqs,
+    dependency_links=dep_links,
+    packages=find_packages(exclude=["setuptools", "tests"]),
+    entry_points={
+        "console_scripts": [
+            "logshipper = logshipper.cmd:main",
+            "logshipper-ship-file = logshipper.cmd:ship_file",
+        ],
+        "logshipper.inputs": [
+            "syslog = logshipper.input:Syslog",
+            "stdin = logshipper.input:Stdin",
+            "tail = logshipper.tail:Tail",
+            "command = logshipper.input:Command",
+        ],
+        "logshipper.filters": [
+            "drop = logshipper.filters:prepare_drop",
+            "edge = logshipper.filters:prepare_edge",
+            "extract = logshipper.filters:prepare_extract",
+            "match = logshipper.filters:prepare_match",
+            "python = logshipper.filters:prepare_python",
+            "replace = logshipper.filters:prepare_replace",
+            "set = logshipper.filters:prepare_set",
+            "strptime = logshipper.filters:prepare_strptime",
+            "unset = logshipper.filters:prepare_unset",
+            "timewindow = logshipper.filters:prepare_timewindow",
+        ],
+        "logshipper.outputs": [
+            "call = logshipper.outputs:prepare_call",
+            "debug = logshipper.outputs:prepare_debug",
+            "elasticsearch = logshipper.elasticsearch:prepare_elasticsearch_http",
+            "fork = logshipper.outputs:prepare_fork",
+            "jump = logshipper.outputs:prepare_jump",
+            "logging = logshipper.pylogging:prepare_logging",
+            "rabbitmq = logshipper.outputs:prepare_rabbitmq",
+            "statsd = logshipper.outputs:prepare_statsd",
+            "stdout = logshipper.outputs:prepare_stdout",
+        ]
+    },
 )


### PR DESCRIPTION
This PR moves install / setup.py process from pbr + setup.cfg to plain setup.py.

I believe this should address st2-packages build failures we've been seeing, but will see going forward.

## Background, Context

Recently I started to notice a lot of random st2-packages build failures with such errors (https://app.circleci.com/pipelines/github/StackStorm/st2/1542/workflows/128ecfa9-04ff-4b05-b410-94541fb12be2/jobs/12968):

```
pip-install-o4a3p1e6/logshipper
[package: st2] [11:07:37]          ERROR: Command errored out with exit status 1:
[package: st2] [11:07:37]           command: /tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-o4a3p1e6/logshipper/setup.py'"'"'; __file__='"'"'/tmp/pip-install-o4a3p1e6/logshipper/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-ys7_dgui
[package: st2] [11:07:37]               cwd: /tmp/pip-install-o4a3p1e6/logshipper/
[package: st2] [11:07:37]          Complete output (23 lines):
[package: st2] [11:07:37]          Couldn't find index page for 'pbr' (maybe misspelled?)
[package: st2] [11:07:37]          No local packages or working download links found for pbr
[package: st2] [11:07:37]          Traceback (most recent call last):
[package: st2] [11:07:37]            File "<string>", line 1, in <module>
[package: st2] [11:07:37]            File "/tmp/pip-install-o4a3p1e6/logshipper/setup.py", line 23, in <module>
[package: st2] [11:07:37]              pbr=True,
[package: st2] [11:07:37]            File "/usr/lib64/python3.6/distutils/core.py", line 108, in setup
[package: st2] [11:07:37]              _setup_distribution = dist = klass(attrs)
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/setuptools/dist.py", line 315, in __init__
[package: st2] [11:07:37]              self.fetch_build_eggs(attrs['setup_requires'])
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/setuptools/dist.py", line 361, in fetch_build_eggs
[package: st2] [11:07:37]              replace_conflicting=True,
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/pkg_resources/__init__.py", line 850, in resolve
[package: st2] [11:07:37]              dist = best[req.key] = env.best_match(req, ws, installer)
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1122, in best_match
[package: st2] [11:07:37]              return self.obtain(req, installer)
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1134, in obtain
[package: st2] [11:07:37]              return installer(requirement)
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/setuptools/dist.py", line 429, in fetch_build_egg
[package: st2] [11:07:37]              return cmd.easy_install(req)
[package: st2] [11:07:37]            File "/tmp/st2/st2/build/BUILDROOT/st2-3.5dev-1.x86_64/opt/stackstorm/st2/lib/python3.6/site-packages/setuptools/command/easy_install.py", line 659, in easy_install
[package: st2] [11:07:37]              raise DistutilsError(msg)
[package: st2] [11:07:37]          distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('pbr')
[package: st2] [11:07:37]          ----------------------------------------
[package: st2] [11:07:37]      ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
[package: st2] [11:07:37]      error: Bad exit status from /var/tmp/rpm-tmp.zQRQ1c (%install)
[package: st2] [11:07:37]          Bad exit status from /var/tmp/rpm-tmp.zQRQ1c (%install)
[package: st2] [11:07:37]      
[package: st2] [11:07:37]      
[package: st2] [11:07:37]      RPM build errors:
```

First I thought it may be related to caching changes, but after some more digging in I now believe it's related to dependency install ordering (+ perhaps to pip changes).

logshipper depends on pbr for installation, but we don't anywhere explicit specify ``pbr`` as an (install) dependency. As such it gets installed as a transitive dependency of some other dependency. If that dependency is installed before logshipper then it will work fine, otherwise it will fail.

Technically, we could also try different workaround (e.g. installing pbr inside st2-packages Makefile, but that seems like a lot of complexity or perhaps even specifying it as dependency in st2 requirements.txt even though that's not great since pbr is install dependency and not a run time one).

P.S. In the future we are also replacing / getting rid of log shipper.